### PR TITLE
Make regex case-insensitive for completed tasks

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -73,6 +73,28 @@ describe('createTaskListText', () => {
 `)
   })
 
+  it('creates a list of completed tasks using uppercase X', () => {
+    const text = `## Issue Type
+
+
+    ## Checklist
+    - [X] I have read the [CONTRIBUTING.md]()
+    - [X] I have made corresponding changes to the documentation
+    - [X] My changes generate no lint errors
+    - [X] I have added tests that prove my fix is effective or that my feature works
+    - [X] New and existing unit tests pass locally with my changes`
+
+    const result = createTaskListText(text)
+
+    expect(result).toEqual(`## :white_check_mark: Completed Tasks
+- [X] I have read the [CONTRIBUTING.md]()
+- [X] I have made corresponding changes to the documentation
+- [X] My changes generate no lint errors
+- [X] I have added tests that prove my fix is effective or that my feature works
+- [X] New and existing unit tests pass locally with my changes
+`)
+  })
+
   it('creates a list of completed tasks and uncompleted tasks', () => {
     const text = `## Issue Type
     

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ export function removeIgnoreTaskLitsText(text: string): string {
 }
 
 export function createTaskListText(body: string): string {
-  const completedTasks = body.match(/(- \[[x]\].+)/g)
+  const completedTasks = body.match(/(- \[[x]\].+)/ig)
   const uncompletedTasks = body.match(/(- \[[ ]\].+)/g)
 
   let text = ''


### PR DESCRIPTION
I've been going crazy waiting for the checks to be completed but then realized that I was checking with an uppercase `X` 😅 

From: https://github.github.com/gfm/#task-list-items-extension-

We can read:

> A task list item marker consists of an optional number of spaces, a left bracket (`[`), either a whitespace character or the letter `x` in either lowercase or uppercase, and then a right bracket (`]`).